### PR TITLE
Add npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+test/
+docs/
+lib/
+.editorconfig
+.eslintrc
+.travis.yml
+gulpfile.js


### PR DESCRIPTION
To limit what goes over the wire for when it's published
to npm.