### PR TITLE
Add the missing -p, --port option to `denali server`

### DIFF
--- a/lib/cli/blueprints/app/files/app/application.js
+++ b/lib/cli/blueprints/app/files/app/application.js
@@ -3,5 +3,6 @@ import { Application } from 'denali';
 
 export default new Application({
   rootDir: path.join(__dirname, '..'),
+  port: process.env.PORT,
   environment: process.env.DENALI_ENV || process.env.NODE_ENV || 'development'
 });

--- a/lib/cli/blueprints/app/files/package.json
+++ b/lib/cli/blueprints/app/files/package.json
@@ -2,8 +2,8 @@
   "name": "<%= name %>",
   "version": "0.0.1",
   "scripts": {
-    "start": "index.js",
-    "test": "./node_modules/.bin/denali test"
+    "start": "denali server",
+    "test": "denali test"
   },
   "private": true,
   "dependencies": {

--- a/lib/cli/server.js
+++ b/lib/cli/server.js
@@ -8,6 +8,7 @@ import nodemon from 'nodemon';
 program
 .option('-e --environment', 'The environment to run under, i.e. "production"')
 .option('-d --debug', 'Runs the server with the node --debug flag, and launches node-inspector')
+.option('-p, --port <port>', 'Sets the port that the server will listen on')
 .parse(process.argv);
 
 let serverPath = path.join(process.cwd(), 'index.js');
@@ -22,7 +23,11 @@ if (program.environment === 'development' || !program.environment) {
   nodemon({
     script: serverPath,
     ignore: [ 'node_modules\/(?!denali)', 'node_modules/denali/node_modules' ],
-    debug: program.debug
+    debug: program.debug,
+    env: assign({
+      DENALI_ENV: program.environment,
+      PORT: program.port
+    }, process.env)
   });
 
   nodemon.on('quit', function() {

--- a/lib/runtime/application.js
+++ b/lib/runtime/application.js
@@ -79,9 +79,9 @@ export default Engine.extend({
       this.injectBlackburnPlusForaker(this.server);
       this.server.use(this.router);
       this.server.use(this.handleErrors.bind(this));
-      this.server.listen(3000, resolve);
+      this.server.listen(this.port, resolve);
     }).then(() => {
-      this.log(`${ this.pkg.name }@${ this.pkg.version } server up on port 3000`);
+      this.log(`${ this.pkg.name }@${ this.pkg.version } server up on port ${this.port}`);
     });
   },
 

--- a/lib/runtime/engine.js
+++ b/lib/runtime/engine.js
@@ -39,6 +39,7 @@ export default CoreObject.extend({
     this._super.apply(this, arguments);
 
     this.env = options.environment || 'development';
+    this.port = options.port || 3000;
 
     this.rootDir = options.rootDir;
     this.appDir = options.appDir || path.join(this.rootDir, 'app');


### PR DESCRIPTION
There were references to the port in the cli server command, but it
was never used anywhere, since 3000 was hard coded.

This now uses process.env.PORT or -p options or 3000.

Also fixed the app blueprint's npm scripts.