### PR TITLE
Fix docs link on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@ $ cd my-api &amp;&amp; denali serve</code>
 
     <div class="cta">
       <h2 class="cta-header">Sound Interesting?</h2>
-      <a class='cta-btn' href='/latest/guides'>
+      <a class='cta-btn' href='latest/guides/introduction'>
         Check out the Guides
       </a>
     </div>


### PR DESCRIPTION
Noticed this while browsing the docs -> url should be relative and point to the right guide page